### PR TITLE
Fix: Add profile_compelete=True check for all and single business

### DIFF
--- a/API/businesses/routes.py
+++ b/API/businesses/routes.py
@@ -459,7 +459,7 @@ def fetch_all_businesses():
         :return: 200
     """
     try:
-        businesses = Business.query.filter_by(active=True, verified=True).all()
+        businesses = Business.query.filter_by(active=True, verified=True, profile_completed=True).all()
         if not businesses:
             return jsonify("Businesses not")
         all_businesses = []
@@ -481,7 +481,7 @@ def fetch_business(slug):
         :return: 404, 200
     """
     try:
-        business = Business.query.filter_by(slug=slug, active=True, verified=True).first()
+        business = Business.query.filter_by(slug=slug, active=True, verified=True, profile_completed=True).first()
 
         if not business:
             return jsonify({"message": "Business doesn't exist"}), 404


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initially after adding the profile_completed = True functionality I added the check to the service businesses to ensure services are only retrieved from a business that has completed their profile.

Asheki business is still visible because the check was applied to the services not the businesses themselves.

- Describe your changes in detail

## Motivation and Context

- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

## How Has This Been Tested?

- Please describe in detail how you tested your changes.
- Include details of your testing environment, and the tests you ran to
- see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

- N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
